### PR TITLE
feat(formatting): indent commit bodies

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -42,13 +42,23 @@ impl CommitSummary {
                     // Add any remaining lines with proper indentation
                     let remaining_lines: Vec<&str> = lines.collect();
                     
-                    // If there are remaining lines, add an extra newline before them
+                    // If there are remaining lines, add an empty line and then the indented body
                     if !remaining_lines.is_empty() {
-                        changelog.push('\n');
+                        // Skip leading empty lines
+                        let mut start_index = 0;
+                        while start_index < remaining_lines.len() && remaining_lines[start_index].is_empty() {
+                            start_index += 1;
+                        }
                         
-                        for line in remaining_lines {
-                            if !line.is_empty() {
-                                changelog.push_str(&format!("{}\n", line));
+                        if start_index < remaining_lines.len() {
+                            changelog.push('\n');
+                            
+                            for line in &remaining_lines[start_index..] {
+                                if line.is_empty() {
+                                    changelog.push('\n');
+                                } else {
+                                    changelog.push_str(&format!("  {}\n", line));
+                                }
                             }
                         }
                     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -330,7 +330,7 @@ fn test_changelog() {
     
     let changelog = changelog.trim_end().to_string(); // Remove trailing newlines
     let expected_changelog = format!(
-        "### What's changed in v1.0.0\n\n* feat: add new feature\n\nBREAKING CHANGE: This removes the old API"
+        "### What's changed in v1.0.0\n\n* feat: add new feature\n\n  BREAKING CHANGE: This removes the old API"
     );
 
     assert_eq!(
@@ -423,6 +423,99 @@ fn test_first_run_scenarios() {
     assert!(changelog.contains("noop: no version change"), "Changelog should contain no-op commit");
     assert!(changelog.contains("chore: cleanup"), "Changelog should contain chore commit");
     assert!(changelog.contains("feat: another feature"), "Changelog should contain another feature");
+    
+    // Tag the version
+    let tag_name = format!("v{}", version);
+    run_and_show_command("git", &["tag", &tag_name], repo_path);
+}
+
+#[test]
+fn test_changelog_formatting() {
+    // Create a new temp dir
+    let temp_dir = tempfile::tempdir().expect("Failed to create temporary directory");
+    let repo_path = temp_dir.path();
+    println!("Temporary directory created at: {:?}", repo_path);
+
+    // Initialize as git repo
+    run_and_show_command("git", &["init"], repo_path);
+    run_and_show_command("git", &["config", "user.name", "patrickleet"], repo_path);
+    run_and_show_command("git", &["config", "user.email", "pat@patscott.io"], repo_path);
+
+    // 1. Add a commit with a simple multi-line body
+    let file_path = repo_path.join("simple-body.md");
+    fs::write(&file_path, "# Simple body commit").expect("Failed to write file");
+    run_and_show_command("git", &["add", file_path.to_str().unwrap()], repo_path);
+    run_and_show_command(
+        "git",
+        &["commit", "-m", "feat: add feature with simple body\n\nThis is a simple commit body\nIt has multiple lines\nThey should be indented"],
+        repo_path
+    );
+
+    // 2. Add a commit with a body that includes empty lines
+    let file_path = repo_path.join("empty-lines.md");
+    fs::write(&file_path, "# Empty lines commit").expect("Failed to write file");
+    run_and_show_command("git", &["add", file_path.to_str().unwrap()], repo_path);
+    run_and_show_command(
+        "git",
+        &["commit", "-m", "fix: fix bug with empty lines in body\n\nThis commit body has empty lines\n\nLike this one above\n\nAnd this one too"],
+        repo_path
+    );
+
+    // 3. Add a commit that resembles a squashed PR from GitHub UI
+    let file_path = repo_path.join("squashed-pr.md");
+    fs::write(&file_path, "# Squashed PR commit").expect("Failed to write file");
+    run_and_show_command("git", &["add", file_path.to_str().unwrap()], repo_path);
+    run_and_show_command(
+        "git",
+        &["commit", "-m", "feat: add feature from squashed PR\n\nThis is a squashed commit that includes the following changes:\n\n- feat(core): create plugin interface\n\n- feat(core): implement plugin loader\n\n- fix(core): handle plugin initialization errors\n\n- test(core): add tests for plugin system"],
+        repo_path
+    );
+
+    // Run vnext and check version
+    let version = run_vnext(repo_path);
+    assert_eq!(version, "0.1.0", "First run version should be 0.1.0");
+    println!("Asserted version {} is 0.1.0", version);
+
+    // Check changelog
+    println!("Running vnext with --changelog to verify changelog output");
+    let project_dir = std::env::current_dir().expect("Failed to get current directory");
+    let binary_path = project_dir.join("target/debug/vnext");
+    let output = Command::new(&binary_path)
+        .args(["--changelog"])
+        .current_dir(&repo_path)
+        .output()
+        .expect("Failed to execute vnext with --changelog");
+    
+    let changelog = String::from_utf8_lossy(&output.stdout).to_string();
+    println!("Changelog output:\n{}", changelog);
+    
+    // Verify changelog formatting
+    let changelog = changelog.trim_end().to_string();
+    
+    // Check that the version header is present
+    assert!(changelog.contains("### What's changed in v0.1.0"), "Changelog should mention version 0.1.0");
+    
+    // Check that all commit titles are present
+    assert!(changelog.contains("* feat: add feature with simple body"), "Changelog should contain first commit title");
+    assert!(changelog.contains("* fix: fix bug with empty lines in body"), "Changelog should contain second commit title");
+    assert!(changelog.contains("* feat: add feature from squashed PR"), "Changelog should contain third commit title");
+    
+    // Check that commit bodies are properly indented
+    assert!(changelog.contains("  This is a simple commit body"), "Commit body should be indented");
+    assert!(changelog.contains("  It has multiple lines"), "Commit body should be indented");
+    assert!(changelog.contains("  They should be indented"), "Commit body should be indented");
+    
+    // Check that empty lines in commit bodies are preserved
+    assert!(changelog.contains("  This commit body has empty lines"), "Commit body should be indented");
+    assert!(changelog.contains("\n\n  Like this one above"), "Empty line should be preserved");
+    assert!(changelog.contains("\n\n  And this one too"), "Empty line should be preserved");
+    
+    // Check that squashed PR format is properly indented
+    assert!(changelog.contains("  This is a squashed commit that includes the following changes:"), "Squashed PR intro should be indented");
+    assert!(changelog.contains("  - feat(core): create plugin interface"), "Squashed PR bullet point should be indented");
+    assert!(changelog.contains("  - feat(core): implement plugin loader"), "Squashed PR bullet point should be indented");
+    assert!(changelog.contains("  - fix(core): handle plugin initialization errors"), "Squashed PR bullet point should be indented");
+    assert!(changelog.contains("  - test(core): add tests for plugin system"), "Squashed PR bullet point should be indented");
     
     // Tag the version
     let tag_name = format!("v{}", version);


### PR DESCRIPTION
# Improved Changelog Formatting

## Feature Description

The changelog formatting has been enhanced to provide better readability for commit messages with multi-line bodies. This improvement is particularly valuable for complex commits such as squashed PRs from GitHub UI that contain multiple bullet points with extra lines between them.

## Key Improvements

1. **Proper Indentation**: All lines in commit bodies are now indented with two spaces, creating a clear visual hierarchy between commit titles and their descriptions.

2. **Empty Line Separation**: An empty line is added between the commit title and its body, providing clear visual separation.

3. **Preserved Structure**: Empty lines within commit bodies are maintained to preserve the original structure and formatting of the message.

4. **Optimized for Squashed PRs**: The formatting is optimized to handle GitHub UI squashed PRs, which typically include bullet points with extra lines between them.

## Before and After Example

### Before:

```
### What's changed in v1.0.0

* feat: add new feature
BREAKING CHANGE: This removes the old API

* feat(core): add support for custom plugins
This is a squashed commit that includes the following changes:
- feat(core): create plugin interface
- feat(core): implement plugin loader
- feat(core): add plugin discovery mechanism
```

### After:

```
### What's changed in v1.0.0

* feat: add new feature

  BREAKING CHANGE: This removes the old API

* feat(core): add support for custom plugins

  This is a squashed commit that includes the following changes:
  
  - feat(core): create plugin interface
  
  - feat(core): implement plugin loader
  
  - feat(core): add plugin discovery mechanism
```

## Implementation Details

The improved formatting is implemented in the `format_changelog` method in `src/version.rs`. The method now:

1. Adds a bullet point to the first line of each commit message
2. Adds an empty line between the commit title and body
3. Indents all non-empty lines in the body with two spaces
4. Preserves empty lines within the body to maintain the original structure
5. Skips leading empty lines in the body to avoid extra newlines

This enhancement makes changelogs more readable and visually appealing, especially for projects that use conventional commits and follow semantic versioning practices.