### PR TITLE
feat: changelog header scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,23 @@ This will output a formatted changelog that includes all commits since the last 
 * chore: update dependencies
 ```
 
+#### Header Scaling in Changelogs
+
+By default, vnext automatically scales down markdown headers in commit bodies to maintain a consistent visual hierarchy in the generated changelog. This is particularly useful when the changelog is displayed in GitHub release notes, where the "What's changed" header is already an H3.
+
+The scaling works as follows:
+- H1 (#) → H4 (####)
+- H2 (##) → H5 (#####)
+- H3 (###) → H6 (######)
+
+Headers H4 and below remain unchanged.
+
+To disable header scaling and preserve the original header levels, use the `--no-header-scaling` flag:
+
+```bash
+vnext --changelog --no-header-scaling
+```
+
 #### GitHub Contributor Information
 
 When the repository is hosted on GitHub (detected by having a remote with "github" in the URL), GitHub contributor information is automatically included in the changelog when using `--changelog`.

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -73,9 +73,10 @@ pub fn output_result(
     next_version: &Version,
     summary: &CommitSummary,
     show_changelog: bool,
+    no_header_scaling: bool,
 ) {
     if show_changelog {
-        println!("{}", summary.format_changelog(next_version));
+        println!("{}", summary.format_changelog(next_version, no_header_scaling));
     } else {
         println!("{}", next_version);
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,10 @@ pub struct Cli {
     #[clap(long)]
     pub changelog: bool,
 
+    /// Disable header scaling in changelog (by default, h1->h4, h2->h5, h3->h6)
+    #[clap(long)]
+    pub no_header_scaling: bool,
+
     /// Subcommands
     #[clap(subcommand)]
     pub command: Option<Commands>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ fn run() -> Result<(), VNextError> {
     }
     
     // Output result
-    changelog::output_result(&next_version, &summary, cli.changelog);
+    changelog::output_result(&next_version, &summary, cli.changelog, cli.no_header_scaling);
     
     Ok(())
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -33,7 +33,7 @@ impl CommitSummary {
         }
     }
 
-    pub fn format_changelog(&self, next_version: &Version) -> String {
+    pub fn format_changelog(&self, next_version: &Version, no_header_scaling: bool) -> String {
         let mut changelog = format!("### What's changed in v{}\n\n", next_version);
         if self.commits.is_empty() {
             changelog.push_str("* No changes\n");
@@ -76,7 +76,22 @@ impl CommitSummary {
                                 if line.is_empty() {
                                     changelog.push('\n');
                                 } else {
-                                    changelog.push_str(&format!("  {}\n", line));
+                                    let processed_line = if !no_header_scaling {
+                                        // Scale down headers in commit body (h1->h4, h2->h5, h3->h6)
+                                        if line.starts_with("# ") {
+                                            format!("#### {}", &line[2..])
+                                        } else if line.starts_with("## ") {
+                                            format!("##### {}", &line[3..])
+                                        } else if line.starts_with("### ") {
+                                            format!("###### {}", &line[4..])
+                                        } else {
+                                            line.to_string()
+                                        }
+                                    } else {
+                                        // No header scaling
+                                        line.to_string()
+                                    };
+                                    changelog.push_str(&format!("  {}\n", processed_line));
                                 }
                             }
                         }

--- a/tests/github_test.rs
+++ b/tests/github_test.rs
@@ -40,7 +40,7 @@ fn test_changelog_with_author_info() {
 
     // Format the changelog
     let version = Version::new(1, 0, 0);
-    let changelog = summary.format_changelog(&version);
+    let changelog = summary.format_changelog(&version, false); // Use default header scaling
 
     // Verify the changelog contains author information
     assert!(changelog.contains("### What's changed in v1.0.0"));
@@ -104,14 +104,14 @@ fn test_github_detection_behavior() {
     ));
 
     let changelog_with_github =
-        summary_with_github.format_changelog(&semver::Version::new(1, 0, 0));
+        summary_with_github.format_changelog(&semver::Version::new(1, 0, 0), false);
     assert!(
         changelog_with_github.contains("(by @testuser)"),
         "Changelog should include GitHub username when GitHub author information is available"
     );
 
     // Test without GitHub author information
-    let changelog_without_github = summary.format_changelog(&semver::Version::new(1, 0, 0));
+    let changelog_without_github = summary.format_changelog(&semver::Version::new(1, 0, 0), false);
     assert!(!changelog_without_github.contains("(by @testuser)"),
         "Changelog should not include GitHub username when GitHub author information is not available");
 }

--- a/tests/header_scaling_tests.rs
+++ b/tests/header_scaling_tests.rs
@@ -1,0 +1,90 @@
+use std::fs;
+use std::process::Command;
+
+// Import the test_helpers module
+mod test_helpers;
+use test_helpers::{run_and_show_command, run_vnext};
+
+#[test]
+fn test_header_scaling() {
+    // Create a new temp dir
+    let temp_dir = tempfile::tempdir().expect("Failed to create temporary directory");
+    let repo_path = temp_dir.path();
+    println!("Temporary directory created at: {:?}", repo_path);
+
+    // Initialize as git repo
+    run_and_show_command("git", &["init"], repo_path);
+    run_and_show_command("git", &["config", "user.name", "patrickleet"], repo_path);
+    run_and_show_command("git", &["config", "user.email", "pat@patscott.io"], repo_path);
+
+    // Add a commit with markdown headers in the body to test header scaling
+    let file_path = repo_path.join("header-scaling.md");
+    fs::write(&file_path, "# Header Scaling Test").expect("Failed to write file");
+    run_and_show_command("git", &["add", file_path.to_str().unwrap()], repo_path);
+    run_and_show_command(
+        "git",
+        &["commit", "-m", "feat: add header scaling test\n\n# H1 Header Should Scale to H4\n\n## H2 Header Should Scale to H5\n\n### H3 Header Should Scale to H6\n\n#### H4 Header Should Also Scale to H6\n\n##### H5 Header Should Also Scale to H6\n\nRegular text should remain unchanged"],
+        repo_path
+    );
+
+    // Run vnext and check version
+    let version = run_vnext(repo_path);
+    assert_eq!(version, "0.1.0", "First run version should be 0.1.0");
+    println!("Asserted version {} is 0.1.0", version);
+
+    // Test 1: Check changelog with header scaling enabled (default)
+    println!("Running vnext with --changelog to verify header scaling (enabled)");
+    let project_dir = std::env::current_dir().expect("Failed to get current directory");
+    let binary_path = project_dir.join("target/debug/vnext");
+    let output = Command::new(&binary_path)
+        .args(["--changelog"])
+        .current_dir(&repo_path)
+        .output()
+        .expect("Failed to execute vnext with --changelog");
+    
+    let changelog = String::from_utf8_lossy(&output.stdout).to_string();
+    println!("Changelog output with header scaling:\n{}", changelog);
+    
+    // Verify changelog formatting
+    let changelog = changelog.trim_end().to_string();
+    
+    // Check that the version header is present
+    assert!(changelog.contains("### What's changed in v0.1.0"), "Changelog should mention version 0.1.0");
+    
+    // Check that commit title is present
+    assert!(changelog.contains("* feat: add header scaling test"), "Changelog should contain commit title");
+    
+    // Check that header scaling works correctly
+    assert!(changelog.contains("  #### H1 Header Should Scale to H4"), "H1 should be scaled to H4");
+    assert!(changelog.contains("  ##### H2 Header Should Scale to H5"), "H2 should be scaled to H5");
+    assert!(changelog.contains("  ###### H3 Header Should Scale to H6"), "H3 should be scaled to H6");
+    assert!(changelog.contains("  Regular text should remain unchanged"), "Regular text should remain unchanged");
+    
+    // Test 2: Check changelog with header scaling disabled
+    println!("Running vnext with --changelog --no-header-scaling to verify disabled header scaling");
+    let output_no_scaling = Command::new(&binary_path)
+        .args(["--changelog", "--no-header-scaling"])
+        .current_dir(&repo_path)
+        .output()
+        .expect("Failed to execute vnext with --changelog --no-header-scaling");
+    
+    let changelog_no_scaling = String::from_utf8_lossy(&output_no_scaling.stdout).to_string();
+    println!("Changelog output without header scaling:\n{}", changelog_no_scaling);
+    
+    // Verify changelog formatting without header scaling
+    let changelog_no_scaling = changelog_no_scaling.trim_end().to_string();
+    
+    // Check that the version header is present
+    assert!(changelog_no_scaling.contains("### What's changed in v0.1.0"), "Changelog should mention version 0.1.0");
+    
+    // Check that commit title is present
+    assert!(changelog_no_scaling.contains("* feat: add header scaling test"), "Changelog should contain commit title");
+    
+    // Check that headers are NOT scaled when disabled
+    assert!(changelog_no_scaling.contains("  # H1 Header Should Scale to H4"), "H1 should not be scaled when disabled");
+    assert!(changelog_no_scaling.contains("  ## H2 Header Should Scale to H5"), "H2 should not be scaled when disabled");
+    assert!(changelog_no_scaling.contains("  ### H3 Header Should Scale to H6"), "H3 should not be scaled when disabled");
+    assert!(changelog_no_scaling.contains("  #### H4 Header Should Also Scale to H6"), "H4 should not be scaled when disabled");
+    assert!(changelog_no_scaling.contains("  ##### H5 Header Should Also Scale to H6"), "H5 should not be scaled when disabled");
+    assert!(changelog_no_scaling.contains("  Regular text should remain unchanged"), "Regular text should remain unchanged");
+}


### PR DESCRIPTION
Scales headers from commit bodies when creating the changelog so they look nicer in relation to the release notes h3 title. H1, H2, and H3 are scaled down three sizes to H4, H5, and H6, respectively.